### PR TITLE
Make beacon interface configurable; fix Linux discovery

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,17 @@
+# Normalize line endings across Windows/Linux/macOS.
+# Repo standard is LF — files are stored and checked out as LF on all platforms
+# so edits from WSL, Linux, or Windows (with or without core.autocrlf) don't drift.
+
+* text=auto eol=lf
+
+# Binary files — never touch
+*.dll    binary
+*.exe    binary
+*.pdb    binary
+*.snk    binary
+*.png    binary
+*.jpg    binary
+*.jpeg   binary
+*.gif    binary
+*.ico    binary
+*.zip    binary

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -17,7 +17,6 @@ pipeline {
                 sh '''
                     dotnet test "Source/DotNetWorkQueue.TaskScheduling.Distributed.TaskScheduler.Tests/DotNetWorkQueue.TaskScheduling.Distributed.TaskScheduler.Tests.csproj" \
                         -f net8.0 --no-build -c Debug \
-                        --filter "Category!=FlakyOnLinux" \
                         --collect:"XPlat Code Coverage" --results-directory coverage/unit
                 '''
 

--- a/Source/DotNetWorkQueue.TaskScheduling.Distributed.TaskScheduler.Tests/TaskSchedulerJobCountSyncTests.cs
+++ b/Source/DotNetWorkQueue.TaskScheduling.Distributed.TaskScheduler.Tests/TaskSchedulerJobCountSyncTests.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Runtime.InteropServices;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
@@ -14,6 +15,13 @@ namespace DotNetWorkQueue.TaskScheduling.Distributed.TaskScheduler.Tests
         private static int _nextPort = 40000 + Random.Shared.Next(0, 10000);
         private static int NextPort() => Interlocked.Increment(ref _nextPort);
 
+        // On Linux, NetMQBeacon's "loopback" mode binds to 127.0.0.1 but sends to 255.255.255.255,
+        // and the kernel will not deliver those broadcasts back to a 127.0.0.1 socket. Use the
+        // first available interface instead, which binds to the subnet broadcast address and works
+        // for same-host peer discovery on both platforms.
+        private static readonly string BeaconInterface =
+            RuntimeInformation.IsOSPlatform(OSPlatform.Linux) ? "" : "loopback";
+
         private readonly ILogger _logger;
 
         public TaskSchedulerJobCountSyncTests(ITestOutputHelper output)
@@ -25,7 +33,7 @@ namespace DotNetWorkQueue.TaskScheduling.Distributed.TaskScheduler.Tests
         public async Task LocalCountIncrementAndDecrement()
         {
             var port = NextPort();
-            var config = new TaskSchedulerMultipleConfiguration(port);
+            var config = new TaskSchedulerMultipleConfiguration(port, BeaconInterface);
             var bus = new TaskSchedulerBus(_logger, config);
             using var sync = new TaskSchedulerJobCountSync(bus, _logger);
 
@@ -45,16 +53,15 @@ namespace DotNetWorkQueue.TaskScheduling.Distributed.TaskScheduler.Tests
         }
 
         [Fact]
-        [Trait("Category", "FlakyOnLinux")]
         public async Task TwoNodesDiscoverEachOtherAndSyncCounts()
         {
             var port = NextPort();
 
-            var config1 = new TaskSchedulerMultipleConfiguration(port);
+            var config1 = new TaskSchedulerMultipleConfiguration(port, BeaconInterface);
             var bus1 = new TaskSchedulerBus(_logger, config1);
             var sync1 = new TaskSchedulerJobCountSync(bus1, _logger);
 
-            var config2 = new TaskSchedulerMultipleConfiguration(port);
+            var config2 = new TaskSchedulerMultipleConfiguration(port, BeaconInterface);
             var bus2 = new TaskSchedulerBus(_logger, config2);
             var sync2 = new TaskSchedulerJobCountSync(bus2, _logger);
 
@@ -93,7 +100,6 @@ namespace DotNetWorkQueue.TaskScheduling.Distributed.TaskScheduler.Tests
         }
 
         [Fact]
-        [Trait("Category", "FlakyOnLinux")]
         public async Task ThreeNodesAllSeeSharedCount()
         {
             var port = NextPort();
@@ -101,7 +107,7 @@ namespace DotNetWorkQueue.TaskScheduling.Distributed.TaskScheduler.Tests
             var syncs = new TaskSchedulerJobCountSync[3];
             for (var i = 0; i < 3; i++)
             {
-                var config = new TaskSchedulerMultipleConfiguration(port);
+                var config = new TaskSchedulerMultipleConfiguration(port, BeaconInterface);
                 var bus = new TaskSchedulerBus(_logger, config);
                 syncs[i] = new TaskSchedulerJobCountSync(bus, _logger);
             }

--- a/Source/TaskSchedulerBus.cs
+++ b/Source/TaskSchedulerBus.cs
@@ -34,6 +34,7 @@ namespace DotNetWorkQueue.TaskScheduling.Distributed.TaskScheduler
         // Dead nodes timeout
         private readonly TimeSpan _deadNodeTimeout = TimeSpan.FromSeconds(10);
         private readonly int _broadcastPort;
+        private readonly string _beaconInterface;
         private NetMQActor _actor;
         private PublisherSocket _publisher;
         private SubscriberSocket _subscriber;
@@ -54,6 +55,7 @@ namespace DotNetWorkQueue.TaskScheduling.Distributed.TaskScheduler
             _log = log;
             _nodes = new Dictionary<NodeKey, DateTime>();
             _broadcastPort = configuration.BroadCastPort;
+            _beaconInterface = configuration.BeaconInterface;
         }
 
         /// <summary>
@@ -94,8 +96,8 @@ namespace DotNetWorkQueue.TaskScheduling.Distributed.TaskScheduler
                 _subscriber.ReceiveReady += OnSubscriberReady;
 
                 // configure the beacon to listen on the broadcast port
-                _log.LogDebug($"Beacon is being configured to UDP port {_broadcastPort}");
-                _beacon.Configure(_broadcastPort, "loopback");
+                _log.LogDebug($"Beacon is being configured to UDP port {_broadcastPort} on interface '{_beaconInterface}'");
+                _beacon.Configure(_broadcastPort, _beaconInterface);
 
                 // publishing the random port to all other nodes
                 _log.LogDebug($"Beacon is publishing the Bus subscriber port {_randomPort}");
@@ -144,7 +146,16 @@ namespace DotNetWorkQueue.TaskScheduling.Distributed.TaskScheduler
             }
             else if (command == TaskSchedulerBusCommands.GetHostAddress.ToString())
             {
-                var address = _beacon.HostName + ":" + _randomPort;
+                // NetMQBeacon.HostName returns empty string when the beacon is bound to all
+                // interfaces or when its reverse DNS lookup fails (common on CI hosts without
+                // DNS, and in WSL). The host portion of _hostAddress is informational — the
+                // port is what matters downstream — but it still has to parse as a valid URI.
+                var hostName = _beacon.HostName;
+                if (string.IsNullOrEmpty(hostName))
+                {
+                    hostName = "127.0.0.1";
+                }
+                var address = hostName + ":" + _randomPort;
                 _shim.SendFrame(address);
             }
         }

--- a/Source/TaskSchedulerMultipleConfiguration.cs
+++ b/Source/TaskSchedulerMultipleConfiguration.cs
@@ -27,9 +27,22 @@ namespace DotNetWorkQueue.TaskScheduling.Distributed.TaskScheduler
         /// Initializes a new instance of the <see cref="TaskSchedulerMultipleConfiguration"/> class.
         /// </summary>
         /// <param name="port">The port to run the bus on.</param>
-        public TaskSchedulerMultipleConfiguration(int port)
+        /// <param name="beaconInterface">
+        /// The interface name or IP address that the UDP beacon should bind to.
+        /// <para/>
+        /// Valid values (interpreted by <c>NetMQBeacon</c>):
+        /// <list type="bullet">
+        ///   <item><c>"loopback"</c> — bind to <c>127.0.0.1</c> and broadcast to <c>255.255.255.255</c>. Works on Windows only; on Linux the socket will not receive its own broadcasts.</item>
+        ///   <item><c>"*"</c> — bind to all interfaces (<c>0.0.0.0</c>) and broadcast to <c>255.255.255.255</c>.</item>
+        ///   <item><c>""</c> (empty) — bind to the first available non-loopback interface and use its subnet broadcast address. Works cross-platform; discovery is scoped to the local subnet.</item>
+        ///   <item>An IP address (e.g. <c>"192.168.1.42"</c>) — bind to the interface with that address.</item>
+        /// </list>
+        /// Defaults to <c>"loopback"</c> to preserve prior behavior.
+        /// </param>
+        public TaskSchedulerMultipleConfiguration(int port, string beaconInterface = "loopback")
         {
             BroadCastPort = port;
+            BeaconInterface = beaconInterface;
         }
 
         /// <summary>
@@ -39,5 +52,13 @@ namespace DotNetWorkQueue.TaskScheduling.Distributed.TaskScheduler
         /// The broad cast port.
         /// </value>
         public int BroadCastPort { get; }
+
+        /// <summary>
+        /// Gets the interface name or IP address that the UDP beacon should bind to.
+        /// </summary>
+        /// <value>
+        /// The beacon interface. See the constructor documentation for accepted values.
+        /// </value>
+        public string BeaconInterface { get; }
     }
 }

--- a/Source/TaskSchedulerSetup.cs
+++ b/Source/TaskSchedulerSetup.cs
@@ -28,14 +28,20 @@ namespace DotNetWorkQueue.TaskScheduling.Distributed.TaskScheduler
         /// </summary>
         /// <param name="container">The container.</param>
         /// <param name="broadCastPort">The broad cast port to use.</param>
+        /// <param name="beaconInterface">
+        /// The interface the UDP beacon should bind to. Defaults to <c>"loopback"</c>. See
+        /// <see cref="TaskSchedulerMultipleConfiguration(int, string)"/> for valid values. On Linux,
+        /// <c>"loopback"</c> does not deliver broadcasts back to sibling processes — use <c>""</c> to
+        /// bind to the first available interface instead.
+        /// </param>
         /// <remarks>Each scheduler that shares a port will attempt to limit threads by the shared pool</remarks>
-        public static void InjectDistributedTaskScheduler(this IContainer container, int broadCastPort = 9999)
+        public static void InjectDistributedTaskScheduler(this IContainer container, int broadCastPort = 9999, string beaconInterface = "loopback")
         {
             container.Register<ITaskSchedulerBus, TaskSchedulerBus>(LifeStyles.Singleton);
             container.Register<ITaskSchedulerJobCountSync, TaskSchedulerJobCountSync>(LifeStyles.Singleton);
             container.Register<ATaskScheduler, TaskSchedulerMultiple>(LifeStyles.Singleton);
 
-            var configuration = new TaskSchedulerMultipleConfiguration(broadCastPort);
+            var configuration = new TaskSchedulerMultipleConfiguration(broadCastPort, beaconInterface);
             container.Register(() => configuration, LifeStyles.Singleton);
         }
     }


### PR DESCRIPTION
NetMQBeacon's "loopback" mode binds to 127.0.0.1 but sends to 255.255.255.255, and the Linux kernel will not loop that broadcast back to a 127.0.0.1 socket. Peer discovery only ever worked on Windows; on Linux every node saw only its own count.

- Add BeaconInterface to TaskSchedulerMultipleConfiguration (default "loopback" preserves existing Windows behavior)
- TaskSchedulerSetup.InjectDistributedTaskScheduler exposes the beaconInterface parameter
- Tests pick the interface per-OS: "loopback" on Windows, "" (first interface) on Linux
- Guard against empty NetMQBeacon.HostName in GetHostAddress -- reverse DNS on CI/WSL returns empty and crashed URI parsing
- Remove FlakyOnLinux trait from both multi-node tests and drop the --filter from Jenkinsfile

Verified: all 3 tests pass on Linux (WSL) in ~18s. Closes #4.